### PR TITLE
feat: Support user-defined download directory for media

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/DownloadDirectoryPickerDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/DownloadDirectoryPickerDialog.java
@@ -1,0 +1,63 @@
+package com.cappielloantonio.tempo.ui.dialog;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.cappielloantonio.tempo.R;
+
+public class DownloadDirectoryPickerDialog extends DialogFragment {
+
+    private ActivityResultLauncher<Intent> folderPickerLauncher;
+
+    @NonNull
+    @Override
+    public android.app.Dialog onCreateDialog(Bundle savedInstanceState) {
+        // Register launcher *before* button triggers
+        folderPickerLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
+                if (result.getResultCode() == android.app.Activity.RESULT_OK) {
+                    Intent data = result.getData();
+                    if (data != null) {
+                        Uri uri = data.getData();
+                        if (uri != null) {
+                            requireContext().getContentResolver().takePersistableUriPermission(
+                                uri,
+                                Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                            );
+
+                            requireContext().getSharedPreferences("tempo_prefs", Context.MODE_PRIVATE)
+                                .edit()
+                                .putString("download_directory_uri", uri.toString())
+                                .apply();
+
+                            Toast.makeText(requireContext(), "Download directory set:\n" + uri.toString(), Toast.LENGTH_LONG).show();
+                        }
+                    }
+                }
+            }
+        );
+
+        return new MaterialAlertDialogBuilder(requireContext())
+            .setTitle("Set Download Directory")
+            .setMessage("Choose a folder where downloaded songs will be stored.")
+            .setPositiveButton("Choose Folder", (dialog, which) -> {
+                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+                intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                              | Intent.FLAG_GRANT_READ_URI_PERMISSION
+                              | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                folderPickerLauncher.launch(intent);
+            })
+            .setNegativeButton(android.R.string.cancel, null)
+            .create();
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -39,6 +39,9 @@ import com.cappielloantonio.tempo.util.MusicUtil;
 import com.cappielloantonio.tempo.viewmodel.AlbumPageViewModel;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import androidx.media3.common.MediaItem;
+import com.cappielloantonio.tempo.util.ExternalAudioWriter;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Objects;
@@ -106,7 +109,15 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
         if (item.getItemId() == R.id.action_download_album) {
             albumPageViewModel.getAlbumSongLiveList().observe(getViewLifecycleOwner(), songs -> {
-                DownloadUtil.getDownloadTracker(requireContext()).download(MappingUtil.mapDownloads(songs), songs.stream().map(Download::new).collect(Collectors.toList()));
+                DownloadUtil.getDownloadTracker(requireContext()).download(
+                    MappingUtil.mapDownloads(songs),
+                    songs.stream().map(Download::new).collect(Collectors.toList())
+                );
+
+                MappingUtil.mapMediaItems(songs).forEach(media -> {
+                    String title = media.mediaMetadata.title != null ? media.mediaMetadata.title.toString() : media.mediaId;
+                    ExternalAudioWriter.downloadToUserDirectory(requireContext(), media, title);
+                });
             });
             return true;
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DirectoryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DirectoryFragment.java
@@ -37,6 +37,9 @@ import com.cappielloantonio.tempo.util.MappingUtil;
 import com.cappielloantonio.tempo.viewmodel.DirectoryViewModel;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -71,6 +74,9 @@ public class DirectoryFragment extends Fragment implements ClickCallback {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         activity = (MainActivity) getActivity();
+
+        SharedPreferences prefs = requireContext().getSharedPreferences("tempo_prefs", Context.MODE_PRIVATE);
+        String uriString = prefs.getString("download_directory_uri", null);
 
         bind = FragmentDirectoryBinding.inflate(inflater, container, false);
         View view = bind.getRoot();

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DownloadFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DownloadFragment.java
@@ -33,6 +33,13 @@ import com.cappielloantonio.tempo.viewmodel.DownloadViewModel;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.app.Activity;
+import android.net.Uri;
+import android.widget.Toast;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -40,6 +47,8 @@ import java.util.Objects;
 @UnstableApi
 public class DownloadFragment extends Fragment implements ClickCallback {
     private static final String TAG = "DownloadFragment";
+    private static final int REQUEST_CODE_PICK_DIRECTORY = 1002;
+    private SharedPreferences prefs;
 
     private FragmentDownloadBinding bind;
     private MainActivity activity;
@@ -60,6 +69,7 @@ public class DownloadFragment extends Fragment implements ClickCallback {
         View view = bind.getRoot();
         downloadViewModel = new ViewModelProvider(requireActivity()).get(DownloadViewModel.class);
 
+        prefs = requireContext().getSharedPreferences("tempo_prefs", Context.MODE_PRIVATE);
         return view;
     }
 
@@ -216,6 +226,10 @@ public class DownloadFragment extends Fragment implements ClickCallback {
                 downloadViewModel.initViewStack(new DownloadStack(Constants.DOWNLOAD_TYPE_YEAR, null));
                 Preferences.setDefaultDownloadViewType(Constants.DOWNLOAD_TYPE_YEAR);
                 return true;
+            } else if (menuItem.getItemId() == R.id.menu_download_set_directory) { 
+                Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+                startActivityForResult(intent, REQUEST_CODE_PICK_DIRECTORY);
+                return true;
             }
 
             return false;
@@ -266,5 +280,21 @@ public class DownloadFragment extends Fragment implements ClickCallback {
     @Override
     public void onDownloadGroupLongClick(Bundle bundle) {
         Navigation.findNavController(requireView()).navigate(R.id.downloadBottomSheetDialog, bundle);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == REQUEST_CODE_PICK_DIRECTORY && resultCode == Activity.RESULT_OK) {
+            Uri uri = data.getData();
+            if (uri != null) {
+                requireContext().getContentResolver().takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                );
+                prefs.edit().putString("download_directory_uri", uri.toString()).apply();
+                Toast.makeText(requireContext(), "Download directory set", Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -62,6 +62,9 @@ import com.cappielloantonio.tempo.viewmodel.HomeViewModel;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import androidx.media3.common.MediaItem;
+import com.cappielloantonio.tempo.util.ExternalAudioWriter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -274,6 +277,10 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
                         for (Child song : songs) {
                             if (!manager.isDownloaded(song.getId())) {
                                 toSync.add(song.getTitle());
+
+                                MediaItem item = MappingUtil.mapMediaItem(song);
+                                String title = item.mediaMetadata.title != null ? item.mediaMetadata.title.toString() : item.mediaId;
+                                ExternalAudioWriter.downloadToUserDirectory(requireContext(), item, title);
                             }
                         }
 
@@ -302,6 +309,10 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
                             for (Child song : songs) {
                                 if (!manager.isDownloaded(song.getId())) {
                                     manager.download(MappingUtil.mapDownload(song), new Download(song));
+
+                                    MediaItem item = MappingUtil.mapMediaItem(song);
+                                    String title = item.mediaMetadata.title != null ? item.mediaMetadata.title.toString() : item.mediaId;
+                                    ExternalAudioWriter.downloadToUserDirectory(requireContext(), item, title);
                                 }
                             }
                         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -40,6 +40,11 @@ import com.cappielloantonio.tempo.util.MusicUtil;
 import com.cappielloantonio.tempo.viewmodel.PlaylistPageViewModel;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import android.content.Intent;
+import android.net.Uri;
+import androidx.media3.common.MediaItem;
+import com.cappielloantonio.tempo.util.ExternalAudioWriter;
+
 import java.util.Collections;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -137,6 +142,10 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
                                 return toDownload;
                             }).collect(Collectors.toList())
                     );
+                    MappingUtil.mapMediaItems(songs).forEach(media -> {
+                        String title = media.mediaMetadata.title != null ? media.mediaMetadata.title.toString() : media.mediaId;
+                        ExternalAudioWriter.downloadToUserDirectory(requireContext(), media, title);
+                    });
                 }
             });
             return true;

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
@@ -1,13 +1,16 @@
 package com.cappielloantonio.tempo.ui.fragment;
 
+import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.media.audiofx.AudioEffect;
+import android.net.Uri;
 import android.os.Bundle;
-import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -47,15 +50,40 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     private MainActivity activity;
     private SettingViewModel settingViewModel;
 
-    private ActivityResultLauncher<Intent> someActivityResultLauncher;
+    private ActivityResultLauncher<Intent> equalizerResultLauncher;
+    private ActivityResultLauncher<Intent> directoryPickerLauncher;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        someActivityResultLauncher = registerForActivityResult(
+        equalizerResultLauncher = registerForActivityResult(
+                new ActivityResultContracts.StartActivityForResult(),
+                result -> {}
+        );
+
+        directoryPickerLauncher = registerForActivityResult(
                 new ActivityResultContracts.StartActivityForResult(),
                 result -> {
+                    if (result.getResultCode() == Activity.RESULT_OK) {
+                        Intent data = result.getData();
+                        if (data != null) {
+                            Uri uri = data.getData();
+                            if (uri != null) {
+                                requireContext().getContentResolver().takePersistableUriPermission(
+                                    uri,
+                                    Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                                );
+
+                                requireContext().getSharedPreferences("tempo_prefs", Context.MODE_PRIVATE)
+                                    .edit()
+                                    .putString("download_directory_uri", uri.toString())
+                                    .apply();
+
+                                Toast.makeText(requireContext(), "Download folder set.", Toast.LENGTH_SHORT).show();
+                            }
+                        }
+                    }
                 });
     }
 
@@ -97,6 +125,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         actionSyncStarredTracks();
         actionChangeStreamingCacheStorage();
         actionChangeDownloadStorage();
+        actionSetDownloadDirectory();
         actionDeleteDownloadStorage();
         actionKeepScreenOn();
     }
@@ -130,7 +159,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
 
         if ((intent.resolveActivity(requireActivity().getPackageManager()) != null)) {
             equalizer.setOnPreferenceClickListener(preference -> {
-                someActivityResultLauncher.launch(intent);
+                equalizerResultLauncher.launch(intent);
                 return true;
             });
         } else {
@@ -287,6 +316,31 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             dialog.show(activity.getSupportFragmentManager(), null);
             return true;
         });
+    }
+
+    private void actionSetDownloadDirectory() {
+        Preference pref = findPreference("set_download_directory");
+        if (pref != null) {
+            pref.setOnPreferenceClickListener(preference -> {
+                String current = requireContext().getSharedPreferences("tempo_prefs", Context.MODE_PRIVATE)
+                    .getString("download_directory_uri", null);
+
+                if (current != null) {
+                    requireContext().getSharedPreferences("tempo_prefs", Context.MODE_PRIVATE)
+                        .edit()
+                        .remove("download_directory_uri")
+                        .apply();
+                    Toast.makeText(requireContext(), "Download folder cleared.", Toast.LENGTH_SHORT).show();
+                } else {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+            intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION
+                | Intent.FLAG_GRANT_READ_URI_PERMISSION
+                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            directoryPickerLauncher.launch(intent);
+                }
+            return true;
+        });
+        }
     }
 
     private void actionDeleteDownloadStorage() {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/SongBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/SongBottomSheetDialog.java
@@ -39,6 +39,10 @@ import com.cappielloantonio.tempo.viewmodel.SongBottomSheetViewModel;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import android.content.Intent;
+import androidx.media3.common.MediaItem;
+import com.cappielloantonio.tempo.util.ExternalAudioWriter;
+
 import java.util.ArrayList;
 import java.util.Collections;
 
@@ -163,6 +167,9 @@ public class SongBottomSheetDialog extends BottomSheetDialogFragment implements 
                     MappingUtil.mapDownload(song),
                     new Download(song)
             );
+            MediaItem item = MappingUtil.mapMediaItem(song);
+            String title = item.mediaMetadata.title != null ? item.mediaMetadata.title.toString() : item.mediaId;
+            ExternalAudioWriter.downloadToUserDirectory(requireContext(), item, title);
             dismissBottomSheet();
         });
 

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
@@ -1,0 +1,176 @@
+package com.cappielloantonio.tempo.util;
+
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
+import android.provider.Settings;
+import android.webkit.MimeTypeMap;
+import android.widget.Toast;
+
+import androidx.core.app.NotificationCompat;
+import androidx.documentfile.provider.DocumentFile;
+import androidx.media3.common.MediaItem;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.text.Normalizer;
+import java.util.Locale;
+
+public class ExternalAudioWriter {
+
+    private static String sanitizeFileName(String name) {
+        String sanitized = name.replaceAll("[\\/:*?\\\"<>|]", "_");
+        sanitized = sanitized.replaceAll("\\s+", " ").trim();
+        return sanitized;
+    }
+
+    private static String normalizeForComparison(String name) {
+        String s = sanitizeFileName(name);
+        s = Normalizer.normalize(s, Normalizer.Form.NFKD);
+        s = s.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+        return s.toLowerCase(Locale.ROOT);
+    }
+
+    private static DocumentFile findFile(DocumentFile dir, String fileName) {
+        String normalized = normalizeForComparison(fileName);
+        for (DocumentFile file : dir.listFiles()) {
+            String existing = file.getName();
+            if (existing != null && normalizeForComparison(existing).equals(normalized)) {
+                return file;
+            }
+        }
+        return null;
+    }
+
+    public static void downloadToUserDirectory(Context context, MediaItem mediaItem, String fallbackName) {
+        new Thread(() -> {
+            SharedPreferences prefs = context.getSharedPreferences("tempo_prefs", Context.MODE_PRIVATE);
+            String uriString = prefs.getString("download_directory_uri", null);
+
+            if (uriString == null) {
+                notifyUnavailable(context);
+                return;
+            }
+
+            Uri treeUri = Uri.parse(uriString);
+            DocumentFile directory = DocumentFile.fromTreeUri(context, treeUri);
+            if (directory == null || !directory.canWrite()) {
+                notifyFailure(context, "Cannot write to folder.");
+                return;
+            }
+
+            try {
+                Uri mediaUri = mediaItem.requestMetadata.mediaUri;
+                if (mediaUri == null) {
+                    notifyFailure(context, "Invalid media URI.");
+                    return;
+                }
+
+                HttpURLConnection connection = (HttpURLConnection) new URL(mediaUri.toString()).openConnection();
+                connection.connect();
+
+                String mimeType = connection.getContentType();
+                if (mimeType == null) mimeType = "application/octet-stream";
+
+                String extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
+                if (extension == null) extension = "bin";
+
+                String artist = mediaItem.mediaMetadata.artist != null ? mediaItem.mediaMetadata.artist.toString() : "";
+                String title = mediaItem.mediaMetadata.title != null ? mediaItem.mediaMetadata.title.toString() : fallbackName;
+                String album = mediaItem.mediaMetadata.albumTitle != null ? mediaItem.mediaMetadata.albumTitle.toString() : "";
+                String name = artist.isEmpty() ? title : artist + " - " + title;
+                if (!album.isEmpty()) name += " (" + album + ")";
+
+                String sanitized = sanitizeFileName(name);
+                String fullName = sanitized + "." + extension;
+
+                DocumentFile existingFile = findFile(directory, fullName);
+                long remoteLength = connection.getContentLengthLong();
+                if (existingFile != null && existingFile.exists()) {
+                    long localLength = existingFile.length();
+                    if (remoteLength > 0 && localLength == remoteLength) {
+                        notifyExists(context, fullName);
+                        return;
+                    } else {
+                        existingFile.delete();
+                    }
+                }
+
+                DocumentFile targetFile = directory.createFile(mimeType, fullName);
+                if (targetFile == null) {
+                    notifyFailure(context, "Failed to create file.");
+                    return;
+                }
+
+                try (InputStream in = connection.getInputStream();
+                OutputStream out = context.getContentResolver().openOutputStream(targetFile.getUri())) {
+                    if (out == null) {
+                        notifyFailure(context, "Cannot open output stream.");
+                        return;
+                    }
+
+                    byte[] buffer = new byte[8192];
+                    int len;
+                    long total = 0;
+                    while ((len = in.read(buffer)) != -1) {
+                        out.write(buffer, 0, len);
+                        total += len;
+                    }
+
+                    if (remoteLength > 0 && total != remoteLength) {
+                        targetFile.delete();
+                        notifyFailure(context, "Incomplete download.");
+                    } else {
+                        notifySuccess(context, fullName);
+                    }
+                }
+            } catch (Exception e) {
+                notifyFailure(context, e.getMessage());
+            }
+        }).start();
+    }
+
+    private static void notifyUnavailable(Context context) {
+        NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        Intent settingsIntent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", context.getPackageName(), null));
+        PendingIntent openSettings = PendingIntent.getActivity(context, 0, settingsIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
+            .setContentTitle("No download folder set")
+            .setContentText("Tap to set one in settings")
+            .setSmallIcon(android.R.drawable.stat_notify_error)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setSilent(true)
+            .setContentIntent(openSettings)
+            .setAutoCancel(true);
+
+        manager.notify(1011, builder.build());
+    }
+
+    private static void notifyFailure(Context context, String message) {
+        new Handler(Looper.getMainLooper()).post(() ->
+            Toast.makeText(context, "External download failed: " + message, Toast.LENGTH_LONG).show()
+        );
+    }
+
+    private static void notifySuccess(Context context, String name) {
+        new Handler(Looper.getMainLooper()).post(() ->
+            Toast.makeText(context, "Download success: " + name, Toast.LENGTH_SHORT).show()
+        );
+    }
+
+    private static void notifyExists(Context context, String name) {
+        new Handler(Looper.getMainLooper()).post(() ->
+            Toast.makeText(context, "Already exists: " + name, Toast.LENGTH_SHORT).show()
+        );
+    }
+}

--- a/app/src/main/res/menu/download_popup_menu.xml
+++ b/app/src/main/res/menu/download_popup_menu.xml
@@ -16,4 +16,7 @@
     <item
         android:id="@+id/menu_download_group_by_year"
         android:title="@string/menu_group_by_year" />
+    <item
+        android:id="@+id/menu_download_set_directory"
+        android:title="@string/download_directory_set" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="download_directory_dialog_positive_button">Download</string>
     <string name="download_directory_dialog_summary">All tracks in this folder will be downloaded. Tracks present in subfolders will not be downloaded.</string>
     <string name="download_directory_dialog_title">Download the tracks</string>
+    <string name="download_directory_set">Set where music is downloaded</string>
     <string name="download_info_empty_subtitle">Once you download a song, you\'ll find it here</string>
     <string name="download_info_empty_title">No downloads yet!</string>
     <string name="download_item_multiple_subtitle_formatter">%1$s  •  %2$s items</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -152,6 +152,12 @@
             app:title="@string/settings_download_storage_title" />
 
         <Preference
+            android:key="set_download_directory"
+            android:title="Set Download Folder"
+            android:summary="Choose a folder for downloaded music files"
+            android:order="104" />
+
+        <Preference
             android:key="delete_download_storage"
             app:title="@string/settings_delete_download_storage_title"
             app:summary="@string/settings_delete_download_storage_summary"/>


### PR DESCRIPTION
Adds a setting to the menu where a directory can be nominated for downloaded songs to be saved in original format (versus the special cache storage in the current download scheme). This feature hooks into existing "download" options, reporting via toast when the download succeeds. Normalizes filenames to prevent duplication.

Note: This feature does not replace the existing download mechanism, and is not fully matured. Open to feedback on how to make it more useful