### PR TITLE
fix: hide unnecessary TextViews in AlbumPageFragment when there is no data, fixed incorrect album release date

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ItemDate.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ItemDate.kt
@@ -14,11 +14,20 @@ open class ItemDate : Parcelable {
     var month: Int? = null
     var day: Int? = null
 
-    fun getFormattedDate(): String {
-        val calendar = Calendar.getInstance()
-        val dateFormat = SimpleDateFormat("MMMM dd, yyyy", Locale.getDefault())
+    fun getFormattedDate(): String? {
+        if (year == null && month == null && day == null) return null
 
-        calendar.set(year ?: 0, month ?: 0, day ?: 0)
+        val calendar = Calendar.getInstance()
+        val dateFormat = if (month == null && day == null) {
+            SimpleDateFormat("yyyy", Locale.getDefault())
+        } else if (day == null) {
+            SimpleDateFormat("MMMM yyyy", Locale.getDefault())
+        }
+        else{
+            SimpleDateFormat("MMMM dd, yyyy", Locale.getDefault())
+        }
+
+        calendar.set(year ?: 0, month ?: 1, day ?: 1) // Default to 1 if day is null
 
         return dateFormat.format(calendar.time)
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ItemDate.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ItemDate.kt
@@ -27,7 +27,7 @@ open class ItemDate : Parcelable {
             SimpleDateFormat("MMMM dd, yyyy", Locale.getDefault())
         }
 
-        calendar.set(year ?: 0, month ?: 1, day ?: 1) // Default to 1 if day is null
+        calendar.set(year ?: 0, month ?: 1, day ?: 1)
 
         return dateFormat.format(calendar.time)
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -149,13 +149,16 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
                 bind.albumGenresTextview.setText(album.getGenre());
 
                 if (album.getReleaseDate() != null && album.getOriginalReleaseDate() != null) {
-                    bind.albumReleaseYearsTextview.setVisibility(View.VISIBLE);
+                    if (album.getReleaseDate().getFormattedDate() != null || album.getOriginalReleaseDate().getFormattedDate() != null)
+                        bind.albumReleaseYearsTextview.setVisibility(View.VISIBLE);
+                    else
+                        bind.albumReleaseYearsTextview.setVisibility(View.GONE);
 
-                    if (album.getReleaseDate() == null || album.getOriginalReleaseDate() == null) {
+                    if (album.getReleaseDate().getFormattedDate() == null || album.getOriginalReleaseDate().getFormattedDate() == null) {
                         bind.albumReleaseYearsTextview.setText(getString(R.string.album_page_release_date_label, album.getReleaseDate() != null ? album.getReleaseDate().getFormattedDate() : album.getOriginalReleaseDate().getFormattedDate()));
                     }
 
-                    if (album.getReleaseDate() != null && album.getOriginalReleaseDate() != null) {
+                    if (album.getReleaseDate().getFormattedDate() != null && album.getOriginalReleaseDate().getFormattedDate() != null) {
                         if (Objects.equals(album.getReleaseDate().getYear(), album.getOriginalReleaseDate().getYear()) && Objects.equals(album.getReleaseDate().getMonth(), album.getOriginalReleaseDate().getMonth()) && Objects.equals(album.getReleaseDate().getDay(), album.getOriginalReleaseDate().getDay())) {
                             bind.albumReleaseYearsTextview.setText(getString(R.string.album_page_release_date_label, album.getReleaseDate().getFormattedDate()));
                         } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -146,7 +146,10 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
                 bind.albumArtistLabel.setText(album.getArtist());
                 bind.albumReleaseYearLabel.setText(album.getYear() != 0 ? String.valueOf(album.getYear()) : "");
                 bind.albumSongCountDurationTextview.setText(getString(R.string.album_page_tracks_count_and_duration, album.getSongCount(), album.getDuration() != null ? album.getDuration() / 60 : 0));
-                bind.albumGenresTextview.setText(album.getGenre());
+                if (album.getGenre() != null && !album.getGenre().isEmpty()) {
+                    bind.albumGenresTextview.setText(album.getGenre());
+                    bind.albumGenresTextview.setVisibility(View.VISIBLE);
+                }
 
                 if (album.getReleaseDate() != null && album.getOriginalReleaseDate() != null) {
                     if (album.getReleaseDate().getFormattedDate() != null || album.getOriginalReleaseDate().getFormattedDate() != null)

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -144,6 +144,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
 
                 bind.albumNameLabel.setText(album.getName());
                 bind.albumArtistLabel.setText(album.getArtist());
+                bind.albumReleaseYearLabel.setText(album.getYear() != 0 ? String.valueOf(album.getYear()) : "");
                 bind.albumReleaseYearLabel.setVisibility(album.getYear() != 0 ? View.VISIBLE : View.GONE);
                 bind.albumSongCountDurationTextview.setText(getString(R.string.album_page_tracks_count_and_duration, album.getSongCount(), album.getDuration() != null ? album.getDuration() / 60 : 0));
                 if (album.getGenre() != null && !album.getGenre().isEmpty()) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -144,7 +144,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
 
                 bind.albumNameLabel.setText(album.getName());
                 bind.albumArtistLabel.setText(album.getArtist());
-                bind.albumReleaseYearLabel.setText(album.getYear() != 0 ? String.valueOf(album.getYear()) : "");
+                bind.albumReleaseYearLabel.setVisibility(album.getYear() != 0 ? View.VISIBLE : View.GONE);
                 bind.albumSongCountDurationTextview.setText(getString(R.string.album_page_tracks_count_and_duration, album.getSongCount(), album.getDuration() != null ? album.getDuration() / 60 : 0));
                 if (album.getGenre() != null && !album.getGenre().isEmpty()) {
                     bind.albumGenresTextview.setText(album.getGenre());

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -151,6 +151,9 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
                     bind.albumGenresTextview.setText(album.getGenre());
                     bind.albumGenresTextview.setVisibility(View.VISIBLE);
                 }
+                else{
+                    bind.albumGenresTextview.setVisibility(View.GONE);
+                }
 
                 if (album.getReleaseDate() != null && album.getOriginalReleaseDate() != null) {
                     if (album.getReleaseDate().getFormattedDate() != null || album.getOriginalReleaseDate().getFormattedDate() != null)

--- a/app/src/main/res/layout/fragment_album_page.xml
+++ b/app/src/main/res/layout/fragment_album_page.xml
@@ -126,9 +126,11 @@
                         android:layout_marginEnd="18dp"
                         android:text="@string/label_placeholder"
                         android:textAlignment="center"
+                        android:visibility="gone"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:visibility="visible" />
 
                     <TextView
                         android:id="@+id/album_song_count_duration_textview"


### PR DESCRIPTION
This PR fixes some bugs in the album page.

- Year: hide `TextView` when album has no year.
- Genre: hide `TextView` when album has no genre.
- Release date:
  - Fixed incorrect release date displaying as December 31, 0002 when no release date is present. In this case, the release date `TextView` is now hidden.
  - Fixed incorrect release date when only the year is available. Previously, it appeared as December 31 of the previous year because the `getFormattedDate()` method in `subsonic/models/ItemDate.kt` set the calendar's day and month to 0. Setting them to 1 solves the issue. The date format has also been adjusted.

## Screenshots:
<p>Before:</p>
<p>
  <img src="https://github.com/user-attachments/assets/317dfb50-c8ab-4653-8cb2-12200d5f8304" width="250">
  <img src="https://github.com/user-attachments/assets/d0ad145e-d1d8-49d7-983e-d2a602669fb3" width="250">
  <img src="https://github.com/user-attachments/assets/b72651da-0e44-407b-ac39-b15763925473" width="250">
</p>

<p>After:</p>
<p>
  <img src="https://github.com/user-attachments/assets/57cc8fea-15fb-4d3c-bfb7-10f9fa695aff" width="250">
  <img src="https://github.com/user-attachments/assets/b41e30e6-6347-4438-86e1-e8c1df5ae004" width="250">
  <img src="https://github.com/user-attachments/assets/1861a151-3916-4175-abfe-892c2a0d4a11" width="250">
</p>