### PR TITLE
fix: check for IP connectivity instead of Internet access

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/utils/CacheUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/utils/CacheUtil.java
@@ -48,7 +48,7 @@ public class CacheUtil {
                 NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);
 
                 if (capabilities != null) {
-                    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
+                    return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a bug where the app couldn’t connect to a server on the local network if the device was connected to Wi-Fi but there was no active Internet connection.

Previously, logging in to a local server on a wireless local network without Internet access caused a '504' error message to be shown in a `Toast`.