### PR TITLE
fix: show "System default" language option, sort languages alphabetically, include country when showing language in settings

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
@@ -201,12 +201,22 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         localePref.setEntries(entries);
         localePref.setEntryValues(entryValues);
 
-        localePref.setDefaultValue(entryValues[0]);
-        localePref.setSummary(Locale.forLanguageTag(localePref.getValue()).getDisplayLanguage());
+        String value = localePref.getValue();
+        if ("default".equals(value)) {
+            localePref.setSummary(requireContext().getString(R.string.settings_system_language));
+        } else {
+            localePref.setSummary(Locale.forLanguageTag(value).getDisplayLanguage());
+        }
 
         localePref.setOnPreferenceChangeListener((preference, newValue) -> {
-            LocaleListCompat appLocale = LocaleListCompat.forLanguageTags((String) newValue);
-            AppCompatDelegate.setApplicationLocales(appLocale);
+            if ("default".equals(newValue)) {
+                AppCompatDelegate.setApplicationLocales(LocaleListCompat.getEmptyLocaleList());
+                preference.setSummary(requireContext().getString(R.string.settings_system_language));
+            } else {
+                LocaleListCompat appLocale = LocaleListCompat.forLanguageTags((String) newValue);
+                AppCompatDelegate.setApplicationLocales(appLocale);
+                preference.setSummary(Locale.forLanguageTag((String) newValue).getDisplayLanguage());
+            }
             return true;
         });
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
@@ -205,7 +205,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         if ("default".equals(value)) {
             localePref.setSummary(requireContext().getString(R.string.settings_system_language));
         } else {
-            localePref.setSummary(Locale.forLanguageTag(value).getDisplayLanguage());
+            localePref.setSummary(Locale.forLanguageTag(value).getDisplayName());
         }
 
         localePref.setOnPreferenceChangeListener((preference, newValue) -> {
@@ -215,7 +215,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
             } else {
                 LocaleListCompat appLocale = LocaleListCompat.forLanguageTags((String) newValue);
                 AppCompatDelegate.setApplicationLocales(appLocale);
-                preference.setSummary(Locale.forLanguageTag((String) newValue).getDisplayLanguage());
+                preference.setSummary(Locale.forLanguageTag((String) newValue).getDisplayName());
             }
             return true;
         });

--- a/app/src/main/java/com/cappielloantonio/tempo/util/UIUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/UIUtil.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.InsetDrawable;
 import androidx.core.os.LocaleListCompat;
 import androidx.recyclerview.widget.DividerItemDecoration;
 
+import com.cappielloantonio.tempo.App;
 import com.cappielloantonio.tempo.R;
 
 import org.xmlpull.v1.XmlPullParser;
@@ -15,9 +16,10 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -74,17 +76,32 @@ public class UIUtil {
     public static Map<String, String> getLangPreferenceDropdownEntries(Context context) {
         LocaleListCompat localeList = getLocalesFromResources(context);
 
-        Map<String, String> map = new HashMap<>();
+        List<Map.Entry<String, String>> localeArrayList = new ArrayList<>();
+
+        String systemDefaultLabel = App.getContext().getString(R.string.settings_system_language);
+        String systemDefaultValue = "default";
 
         for (int i = 0; i < localeList.size(); i++) {
             Locale locale = localeList.get(i);
-
             if (locale != null) {
-                map.put(Util.toPascalCase(locale.getDisplayName()), locale.toLanguageTag());
+                localeArrayList.add(
+                        new AbstractMap.SimpleEntry<>(
+                                Util.toPascalCase(locale.getDisplayName()),
+                                locale.toLanguageTag()
+                        )
+                );
             }
         }
 
-        return map;
+        localeArrayList.sort(Map.Entry.comparingByKey(String.CASE_INSENSITIVE_ORDER));
+
+        LinkedHashMap<String, String> orderedMap = new LinkedHashMap<>();
+        orderedMap.put(systemDefaultLabel, systemDefaultValue);
+        for (Map.Entry<String, String> entry : localeArrayList) {
+            orderedMap.put(entry.getKey(), entry.getValue());
+        }
+
+        return orderedMap;
     }
 
     public static String getReadableDate(Date date) {

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -164,6 +164,7 @@
     <string name="menu_group_by_artist">Artista</string>
     <string name="settings_image_size">Resolución de la imagen</string>
     <string name="settings_language">Idioma</string>
+    <string name="settings_system_language">Idioma del sistema</string>
     <string name="settings_logout_title">Cerrar sesión</string>
     <string name="settings_github_link">https://github.com/eddyizm/tempo</string>
     <string name="settings_github_summary">Siga el desarrollo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -319,6 +319,7 @@
     <string name="settings_rounded_corner_summary">If enabled, sets a curvature angle for all rendered covers. The changes will take effect on restart.</string>
     <string name="settings_scan_title">Scan library</string>
     <string name="settings_scrobble_title">Enable music scrobbling</string>
+    <string name="settings_system_language">System language</string>
     <string name="settings_share_title">Enable music sharing</string>
     <string name="settings_streaming_cache_size">Size of streaming cache</string>
     <string name="settings_streaming_cache_storage_title">Streaming cache storage</string>


### PR DESCRIPTION
This PR fixes several issues:

- Added an option to set the app language to the system default, which was missing before.
- The language list is now sorted alphabetically. The "system default" option is placed at the top.
- Added country information alongside the language in the app’s settings, to support future translations of the same language in different country variants.

A new string has been added and translated into Spanish.

https://github.com/user-attachments/assets/28190032-c91e-48af-8a70-0ca441347f99