### PR TITLE
fix: make hardcoded strings in home fragment dynamic

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeFragment.java
@@ -80,13 +80,13 @@ public class HomeFragment extends Fragment {
     private void initHomePager() {
         HomePager pager = new HomePager(this);
 
-        pager.addFragment(new HomeTabMusicFragment(), "Music", R.drawable.ic_home);
+        pager.addFragment(new HomeTabMusicFragment(), getString(R.string.home_section_music), R.drawable.ic_home);
 
         if (Preferences.isPodcastSectionVisible())
-            pager.addFragment(new HomeTabPodcastFragment(), "Podcast", R.drawable.ic_graphic_eq);
+            pager.addFragment(new HomeTabPodcastFragment(), getString(R.string.home_section_podcast), R.drawable.ic_graphic_eq);
 
         if (Preferences.isRadioSectionVisible())
-            pager.addFragment(new HomeTabRadioFragment(), "Radio", R.drawable.ic_play_for_work);
+            pager.addFragment(new HomeTabRadioFragment(), getString(R.string.home_section_radio), R.drawable.ic_play_for_work);
 
         bind.homeViewPager.setAdapter(pager);
         bind.homeViewPager.setOffscreenPageLimit(3);

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -104,6 +104,9 @@
     <string name="home_rearrangement_dialog_positive_button">Guardar</string>
     <string name="home_rearrangement_dialog_title">Reorganizar la página de inicio</string>
     <string name="home_rearrangement_dialog_subtitle">Tenga en cuenta que para que los cambios surtan efecto, hay que reiniciar la aplicación.</string>
+    <string name="home_section_music">Música</string>
+    <string name="home_section_podcast">Pódcasts</string>
+    <string name="home_section_radio">Radio</string>
     <string name="home_subtitle_best_of">Mejores pistas de tus artistas favoritos</string>
     <string name="home_subtitle_made_for_you">Iniciar mix desde una cación que te gustó</string>
     <string name="home_subtitle_new_internet_radio_station">Añadir una nueva emisora de radio</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,9 @@
     <string name="home_rearrangement_dialog_positive_button">Save</string>
     <string name="home_rearrangement_dialog_title">Rearrange home</string>
     <string name="home_rearrangement_dialog_subtitle">Please note that in order for the changes made to take effect, it is necessary to restart the application.</string>
+    <string name="home_section_music">Music</string>
+    <string name="home_section_podcast">Podcast</string>
+    <string name="home_section_radio">Radio</string>
     <string name="home_subtitle_best_of">Top songs of your favorite artists</string>
     <string name="home_subtitle_made_for_you">Start mix from a song you liked</string>
     <string name="home_subtitle_new_internet_radio_station">Add a new radio</string>


### PR DESCRIPTION
This PR updates the `HomeFragment` to remove hardcoded strings in section titles "Music", "Podcast" and "Radio" and replace them with dynamic values.

- Created 3 new strings and translated them into Spanish.
- Updated references in the code to use the appropriate resource identifiers.

<img width="380" height="117" alt="fix_strings_home" src="https://github.com/user-attachments/assets/188e5c37-8702-4403-8cf2-a278bfa1ecf7" />