### PR TITLE
fix: Show placeholder string in TrackInfoDialog fields when there is no data

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
@@ -65,12 +65,12 @@ public class TrackInfoDialog extends DialogFragment {
             bind.trackNumberValueSector.setText(mediaMetadata.extras.getInt("track", 0) != 0 ? String.valueOf(mediaMetadata.extras.getInt("track", 0)) : getString(R.string.label_placeholder));
             bind.yearValueSector.setText(mediaMetadata.extras.getInt("year", 0) != 0 ? String.valueOf(mediaMetadata.extras.getInt("year", 0)) : getString(R.string.label_placeholder));
             bind.genreValueSector.setText(mediaMetadata.extras.getString("genre", getString(R.string.label_placeholder)));
-            bind.sizeValueSector.setText(MusicUtil.getReadableByteCount(mediaMetadata.extras.getLong("size", 0)));
+            bind.sizeValueSector.setText(mediaMetadata.extras.getLong("size", 0) != 0 ? MusicUtil.getReadableByteCount(mediaMetadata.extras.getLong("size", 0)) : getString(R.string.label_placeholder));
             bind.contentTypeValueSector.setText(mediaMetadata.extras.getString("contentType", getString(R.string.label_placeholder)));
             bind.suffixValueSector.setText(mediaMetadata.extras.getString("suffix", getString(R.string.label_placeholder)));
             bind.transcodedContentTypeValueSector.setText(mediaMetadata.extras.getString("transcodedContentType", getString(R.string.label_placeholder)));
             bind.transcodedSuffixValueSector.setText(mediaMetadata.extras.getString("transcodedSuffix", getString(R.string.label_placeholder)));
-            bind.durationValueSector.setText(MusicUtil.getReadableDurationString(mediaMetadata.extras.getInt("duration", 0), false));
+            bind.durationValueSector.setText(mediaMetadata.extras.getInt("duration", 0) != 0 ? MusicUtil.getReadableDurationString(mediaMetadata.extras.getInt("duration", 0), false) : getString(R.string.label_placeholder));
             bind.bitrateValueSector.setText(mediaMetadata.extras.getInt("bitrate", 0) != 0 ? mediaMetadata.extras.getInt("bitrate", 0) + " kbps" : getString(R.string.label_placeholder));
             bind.samplingRateValueSector.setText(mediaMetadata.extras.getInt("samplingRate", 0) != 0 ? mediaMetadata.extras.getInt("samplingRate", 0) + " Hz" : getString(R.string.label_placeholder));
             bind.bitDepthValueSector.setText(mediaMetadata.extras.getInt("bitDepth", 0) != 0 ? mediaMetadata.extras.getInt("bitDepth", 0) + " bits" : getString(R.string.label_placeholder));

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
@@ -62,8 +62,8 @@ public class TrackInfoDialog extends DialogFragment {
             bind.titleValueSector.setText(mediaMetadata.extras.getString("title", getString(R.string.label_placeholder)));
             bind.albumValueSector.setText(mediaMetadata.extras.getString("album", getString(R.string.label_placeholder)));
             bind.artistValueSector.setText(mediaMetadata.extras.getString("artist", getString(R.string.label_placeholder)));
-            bind.trackNumberValueSector.setText(String.valueOf(mediaMetadata.extras.getInt("track", 0)));
-            bind.yearValueSector.setText(String.valueOf(mediaMetadata.extras.getInt("year", 0)));
+            bind.trackNumberValueSector.setText(mediaMetadata.extras.getInt("track", 0) != 0 ? String.valueOf(mediaMetadata.extras.getInt("track", 0)) : getString(R.string.label_placeholder));
+            bind.yearValueSector.setText(mediaMetadata.extras.getInt("year", 0) != 0 ? String.valueOf(mediaMetadata.extras.getInt("year", 0)) : getString(R.string.label_placeholder));
             bind.genreValueSector.setText(mediaMetadata.extras.getString("genre", getString(R.string.label_placeholder)));
             bind.sizeValueSector.setText(MusicUtil.getReadableByteCount(mediaMetadata.extras.getLong("size", 0)));
             bind.contentTypeValueSector.setText(mediaMetadata.extras.getString("contentType", getString(R.string.label_placeholder)));
@@ -71,11 +71,11 @@ public class TrackInfoDialog extends DialogFragment {
             bind.transcodedContentTypeValueSector.setText(mediaMetadata.extras.getString("transcodedContentType", getString(R.string.label_placeholder)));
             bind.transcodedSuffixValueSector.setText(mediaMetadata.extras.getString("transcodedSuffix", getString(R.string.label_placeholder)));
             bind.durationValueSector.setText(MusicUtil.getReadableDurationString(mediaMetadata.extras.getInt("duration", 0), false));
-            bind.bitrateValueSector.setText(mediaMetadata.extras.getInt("bitrate", 0) + " kbps");
+            bind.bitrateValueSector.setText(mediaMetadata.extras.getInt("bitrate", 0) != 0 ? mediaMetadata.extras.getInt("bitrate", 0) + " kbps" : getString(R.string.label_placeholder));
             bind.samplingRateValueSector.setText(mediaMetadata.extras.getInt("samplingRate", 0) != 0 ? mediaMetadata.extras.getInt("samplingRate", 0) + " Hz" : getString(R.string.label_placeholder));
             bind.bitDepthValueSector.setText(mediaMetadata.extras.getInt("bitDepth", 0) != 0 ? mediaMetadata.extras.getInt("bitDepth", 0) + " bits" : getString(R.string.label_placeholder));
             bind.pathValueSector.setText(mediaMetadata.extras.getString("path", getString(R.string.label_placeholder)));
-            bind.discNumberValueSector.setText(String.valueOf(mediaMetadata.extras.getInt("discNumber", 0)));
+            bind.discNumberValueSector.setText(mediaMetadata.extras.getInt("discNumber", 0) != 0 ? String.valueOf(mediaMetadata.extras.getInt("discNumber", 0)) : getString(R.string.label_placeholder));
         }
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/TrackInfoDialog.java
@@ -15,6 +15,8 @@ import com.cappielloantonio.tempo.util.MusicUtil;
 import com.cappielloantonio.tempo.util.Preferences;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 
+import java.util.Objects;
+
 public class TrackInfoDialog extends DialogFragment {
     private DialogTrackInfoBinding bind;
 
@@ -51,7 +53,12 @@ public class TrackInfoDialog extends DialogFragment {
 
     private void setTrackInfo() {
         bind.trakTitleInfoTextView.setText(mediaMetadata.title);
-        bind.trakArtistInfoTextView.setText(mediaMetadata.artist);
+        bind.trakArtistInfoTextView.setText(
+                mediaMetadata.artist != null
+                        ? mediaMetadata.artist
+                        : mediaMetadata.extras != null && Objects.equals(mediaMetadata.extras.getString("type"), Constants.MEDIA_TYPE_RADIO)
+                        ? mediaMetadata.extras.getString("uri", getString(R.string.label_placeholder))
+                        : "");
 
         if (mediaMetadata.extras != null) {
             CustomGlideRequest.Builder

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerBottomSheetFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerBottomSheetFragment.java
@@ -174,7 +174,12 @@ public class PlayerBottomSheetFragment extends Fragment {
             playerBottomSheetViewModel.setLiveDescription(mediaMetadata.extras.getString("description", null));
 
             bind.playerHeaderLayout.playerHeaderMediaTitleLabel.setText(mediaMetadata.extras.getString("title"));
-            bind.playerHeaderLayout.playerHeaderMediaArtistLabel.setText(mediaMetadata.extras.getString("artist"));
+            bind.playerHeaderLayout.playerHeaderMediaArtistLabel.setText(
+                    mediaMetadata.artist != null
+                            ? mediaMetadata.artist
+                            : Objects.equals(mediaMetadata.extras.getString("type"), Constants.MEDIA_TYPE_RADIO)
+                            ? mediaMetadata.extras.getString("uri", getString(R.string.label_placeholder))
+                            : "");
 
             CustomGlideRequest.Builder
                     .from(requireContext(), mediaMetadata.extras.getString("coverArtId"), CustomGlideRequest.ResourceType.Song)
@@ -182,7 +187,11 @@ public class PlayerBottomSheetFragment extends Fragment {
                     .into(bind.playerHeaderLayout.playerHeaderMediaCoverImage);
 
             bind.playerHeaderLayout.playerHeaderMediaTitleLabel.setVisibility(mediaMetadata.extras.getString("title") != null && !Objects.equals(mediaMetadata.extras.getString("title"), "") ? View.VISIBLE : View.GONE);
-            bind.playerHeaderLayout.playerHeaderMediaArtistLabel.setVisibility(mediaMetadata.extras.getString("artist") != null && !Objects.equals(mediaMetadata.extras.getString("artist"), "") ? View.VISIBLE : View.GONE);
+            bind.playerHeaderLayout.playerHeaderMediaArtistLabel.setVisibility(
+                    (mediaMetadata.extras.getString("artist") != null && !Objects.equals(mediaMetadata.extras.getString("artist"), ""))
+                            || (Objects.equals(mediaMetadata.extras.getString("type"), Constants.MEDIA_TYPE_RADIO) && mediaMetadata.extras.getString("uri") != null)
+                            ? View.VISIBLE
+                            : View.GONE);
         }
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -146,7 +146,6 @@ public class PlayerControllerFragment extends Fragment {
                 bind.nowPlayingMediaControllerView.setPlayer(mediaBrowser);
                 mediaBrowser.setShuffleModeEnabled(Preferences.isShuffleModeEnabled());
                 mediaBrowser.setRepeatMode(Preferences.getRepeatMode());
-
                 setMediaControllerListener(mediaBrowser);
             } catch (Exception e) {
                 e.printStackTrace();
@@ -181,13 +180,22 @@ public class PlayerControllerFragment extends Fragment {
 
     private void setMetadata(MediaMetadata mediaMetadata) {
         playerMediaTitleLabel.setText(String.valueOf(mediaMetadata.title));
-        playerArtistNameLabel.setText(String.valueOf(mediaMetadata.artist));
+        playerArtistNameLabel.setText(
+                mediaMetadata.artist != null
+                        ? String.valueOf(mediaMetadata.artist)
+                        : mediaMetadata.extras != null && Objects.equals(mediaMetadata.extras.getString("type"), Constants.MEDIA_TYPE_RADIO)
+                        ? mediaMetadata.extras.getString("uri", getString(R.string.label_placeholder))
+                        : "");
 
         playerMediaTitleLabel.setSelected(true);
         playerArtistNameLabel.setSelected(true);
 
         playerMediaTitleLabel.setVisibility(mediaMetadata.title != null && !Objects.equals(mediaMetadata.title, "") ? View.VISIBLE : View.GONE);
-        playerArtistNameLabel.setVisibility(mediaMetadata.artist != null && !Objects.equals(mediaMetadata.artist, "") ? View.VISIBLE : View.GONE);
+        playerArtistNameLabel.setVisibility(
+                (mediaMetadata.artist != null && !Objects.equals(mediaMetadata.artist, ""))
+                        || mediaMetadata.extras != null && Objects.equals(mediaMetadata.extras.getString("type"), Constants.MEDIA_TYPE_RADIO) && mediaMetadata.extras.getString("uri") != null
+                        ? View.VISIBLE
+                        : View.GONE);
     }
 
     private void setMediaInfo(MediaMetadata mediaMetadata) {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
@@ -140,7 +140,6 @@ public class MappingUtil {
         Bundle bundle = new Bundle();
         bundle.putString("id", internetRadioStation.getId());
         bundle.putString("title", internetRadioStation.getName());
-        bundle.putString("artist", uri.toString());
         bundle.putString("uri", uri.toString());
         bundle.putString("type", Constants.MEDIA_TYPE_RADIO);
 
@@ -149,7 +148,6 @@ public class MappingUtil {
                 .setMediaMetadata(
                         new MediaMetadata.Builder()
                                 .setTitle(internetRadioStation.getName())
-                                .setArtist(internetRadioStation.getStreamUrl())
                                 .setExtras(bundle)
                                 .setIsBrowsable(false)
                                 .setIsPlayable(true)

--- a/app/src/notquitemy/java/com/cappielloantonio/tempo/service/MediaService.kt
+++ b/app/src/notquitemy/java/com/cappielloantonio/tempo/service/MediaService.kt
@@ -138,10 +138,19 @@ class MediaService : MediaLibraryService() {
             controller: ControllerInfo,
             mediaItems: List<MediaItem>
         ): ListenableFuture<List<MediaItem>> {
-            val updatedMediaItems = mediaItems.map {
-                it.buildUpon()
-                    .setUri(it.requestMetadata.mediaUri)
-                    .setMediaMetadata(it.mediaMetadata)
+            val updatedMediaItems = mediaItems.map { mediaItem ->
+                val mediaMetadata = mediaItem.mediaMetadata
+
+                val newMetadata = mediaMetadata.buildUpon()
+                    .setArtist(
+                        if (mediaMetadata.artist != null) mediaMetadata.artist
+                        else mediaMetadata.extras?.getString("uri") ?: ""
+                    )
+                    .build()
+
+                mediaItem.buildUpon()
+                    .setUri(mediaItem.requestMetadata.mediaUri)
+                    .setMediaMetadata(newMetadata)
                     .setMimeType(MimeTypes.BASE_TYPE_AUDIO)
                     .build()
             }


### PR DESCRIPTION
This PR fixes these issues:

1. Certain fields in `TrackInfoDialog` displayed 0 when no data was available. They now display the placeholder string "--".
Affected fields: Track number, Year, Size, Duration, Bitrate, Disc Number.
2. When playing a live radio stream, the `TrackInfoDialog` showed the stream URL. Now it has been fixed. When playing a music file, the behavior is the same as before.

## Screenshots
As an example, I used a live radio stream which doesn't have any metadata other than the title.

Before:
<p>
<img width="250" src="https://github.com/user-attachments/assets/dba012b9-5a72-40dd-a947-53f6bd98dd04" />
<img width="250" src="https://github.com/user-attachments/assets/b5c6fa2b-ab83-46dd-9e41-8f8fe751c202" />
</p>

After:
<p>
<img width="250" src="https://github.com/user-attachments/assets/239f95e8-8357-408e-9ac8-20b3abf55948" />
<img width="250" src="https://github.com/user-attachments/assets/7ce5489e-41b8-4669-a936-c88acac7b3b4" />
</p>
