### PR TITLE
feat: added transcoding codec and bitrate info to PlayerControllerFragment, replace hardcoded strings

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -192,7 +192,7 @@ public class PlayerControllerFragment extends Fragment {
 
     private void setMediaInfo(MediaMetadata mediaMetadata) {
         if (mediaMetadata.extras != null) {
-            String extension = mediaMetadata.extras.getString("suffix", "Unknown format");
+            String extension = mediaMetadata.extras.getString("suffix", getString(R.string.player_unknown_format));
             String bitrate = mediaMetadata.extras.getInt("bitrate", 0) != 0 ? mediaMetadata.extras.getInt("bitrate", 0) + "kbps" : "Original";
             String samplingRate = mediaMetadata.extras.getInt("samplingRate", 0) != 0 ? new DecimalFormat("0.#").format(mediaMetadata.extras.getInt("samplingRate", 0) / 1000.0) + "kHz" : "";
             String bitDepth = mediaMetadata.extras.getInt("bitDepth", 0) != 0 ? mediaMetadata.extras.getInt("bitDepth", 0) + "b" : "";
@@ -218,8 +218,8 @@ public class PlayerControllerFragment extends Fragment {
         boolean isTranscodingBitrate = !MusicUtil.getBitratePreference().equals("0");
 
         if (isTranscodingExtension || isTranscodingBitrate) {
-            playerMediaExtension.setText("Transcoding");
-            playerMediaBitrate.setText("requested");
+            playerMediaExtension.setText(MusicUtil.getTranscodingFormatPreference() + " (" + getString(R.string.player_transcoding) + ")");
+            playerMediaBitrate.setText(!MusicUtil.getBitratePreference().equals("0") ? MusicUtil.getBitratePreference() + "kbps" : getString(R.string.player_transcoding_requested));
         }
 
         playerTrackInfo.setOnClickListener(view -> {

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -196,6 +196,9 @@
     <string name="player_playback_speed">%1$.2fx</string>
     <string name="player_queue_clean_all_button">Limpiar la cola de reproducción</string>
     <string name="player_server_priority">Prioridad del servidor</string>
+    <string name="player_unknown_format">Formato desconocido</string>
+    <string name="player_transcoding">Transcodificando</string>
+    <string name="player_transcoding_requested">solicitado</string>
     <string name="playlist_catalogue_title">Catálogo de listas de reproducción</string>
     <string name="playlist_catalogue_title_expanded">Explorar listas de reproducción</string>
     <string name="playlist_chooser_dialog_empty">No hay listas de reproducción</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,6 +193,9 @@
     <string name="player_playback_speed">%1$.2fx</string>
     <string name="player_queue_clean_all_button">Clean play queue</string>
     <string name="player_server_priority">Server Priority</string>
+    <string name="player_unknown_format">Unknown format</string>
+    <string name="player_transcoding">Transcoding</string>
+    <string name="player_transcoding_requested">requested</string>
     <string name="playlist_catalogue_title">Playlist Catalogue</string>
     <string name="playlist_catalogue_title_expanded">Browse Playlists</string>
     <string name="playlist_chooser_dialog_empty">No playlists created</string>


### PR DESCRIPTION
This PR adds support for displaying the current transcoding configuration and bitrate in the player.

Previously, when the user had transcoding enabled, the player showed "Transcoding requested". Now it shows the codec and the bitrate.

I also have replaced and translated into Spanish two hardcoded strings related to transcoding and another one that appears when the format is unknown (usually in radio livestreams).

## Screenshots
Before:
<p>
  <img src="https://github.com/user-attachments/assets/33fb6581-999e-4cc7-9369-83c7d5950b91" width="400">
</p>

After:
<p>
  <img src="https://github.com/user-attachments/assets/aab845cf-0a62-4978-86b0-2b385c74c459" width="400">
</p>