### PR TITLE
style: Add song rating bar in landscape player controller layout

### DIFF
--- a/app/src/main/res/layout-land/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-land/inner_fragment_player_controller_layout.xml
@@ -75,6 +75,39 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <LinearLayout
+        android:id="@+id/rating_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="0dp"
+        android:orientation="horizontal"
+        android:gravity="center"
+        android:scaleX="0.8"
+        android:scaleY="0.8"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/vertical_guideline"
+        app:layout_constraintTop_toBottomOf="@+id/player_media_quality_sector">
+
+        <RatingBar
+            android:id="@+id/song_rating_bar"
+            style="?android:attr/ratingBarStyleIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:numStars="5"
+            android:stepSize="1"
+            android:rating="0"
+            android:isIndicator="false" />
+
+        <TextView
+            android:id="@+id/rating_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textSize="12sp"
+            android:textColor="?attr/colorOnSurfaceVariant"
+            android:text=""/>
+    </LinearLayout>
+
     <TextView
         android:id="@+id/player_media_title_label"
         style="@style/HeadlineLarge"


### PR DESCRIPTION
This PR adds the song rating bar in landscape mode and fixes a bug where the app crashed when switching to landscape mode because the rating bar was missing.

<p>
  <img src="https://github.com/user-attachments/assets/c5673bfe-616b-42f0-8658-fa2da7315178" width="400">
</p>