### PR TITLE
fix: Use correct SearchView widget to avoid crash in AlbumListPageFragment

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
@@ -12,7 +12,7 @@ import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.PopupMenu;
-import android.widget.SearchView;
+import androidx.appcompat.widget.SearchView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;


### PR DESCRIPTION
This PR fixes a bug where accessing "Recently played", "Recently added", "Most played", or other screens which use `AlbumListPageFragment` crashed the app due to an incorrect widget import.

This was caused by the new `artist_list_menu.xml` which uses an `androidx.appcompat.widget.SearchView` instead of the old `android.widget.SearchView`.