### PR TITLE
style: Center subtitle text in empty_download_layout in fragment_download.xml when there is more than one line

### DIFF
--- a/app/src/main/res/layout/fragment_download.xml
+++ b/app/src/main/res/layout/fragment_download.xml
@@ -49,8 +49,9 @@
         <TextView
             android:id="@+id/subtitle_empty_description_label"
             style="@style/LabelSmall"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
             android:paddingStart="56dp"
             android:paddingEnd="56dp"
             android:text="@string/download_info_empty_subtitle" />


### PR DESCRIPTION
This PR centers the text that appears as a subtitle in the downloads fragment when there are no downloads. The text wasn't centered if it took more than one line.

Before and after:
<p>
<img src="https://github.com/user-attachments/assets/fb5c715f-55a6-481d-811e-361160f5bbf0" width="250">
<img src="https://github.com/user-attachments/assets/5640de1d-41e0-40f8-abcf-1657d9836377" width="250">
</p>
