### PR TITLE
fix: Disable "sync starred tracks/albums" switches when Cancel is clicked in warning dialog, use proper view for "Sync starred albums" dialog

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/StarredAlbumSyncDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/StarredAlbumSyncDialog.java
@@ -26,6 +26,12 @@ import java.util.stream.Collectors;
 public class StarredAlbumSyncDialog extends DialogFragment {
     private StarredAlbumsSyncViewModel starredAlbumsSyncViewModel;
 
+    private Runnable onCancel;
+
+    public StarredAlbumSyncDialog(Runnable onCancel) {
+        this.onCancel = onCancel;
+    }
+
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -74,6 +80,7 @@ public class StarredAlbumSyncDialog extends DialogFragment {
             Button negativeButton = dialog.getButton(Dialog.BUTTON_NEGATIVE);
             negativeButton.setOnClickListener(v -> {
                 Preferences.setStarredAlbumsSyncEnabled(false);
+                if (onCancel != null) onCancel.run();
                 dialog.dismiss();
             });
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/StarredAlbumSyncDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/StarredAlbumSyncDialog.java
@@ -12,7 +12,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
 
 import com.cappielloantonio.tempo.R;
-import com.cappielloantonio.tempo.databinding.DialogStarredSyncBinding;
+import com.cappielloantonio.tempo.databinding.DialogStarredAlbumSyncBinding;
 import com.cappielloantonio.tempo.model.Download;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 import com.cappielloantonio.tempo.util.MappingUtil;
@@ -35,7 +35,7 @@ public class StarredAlbumSyncDialog extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
-        DialogStarredSyncBinding bind = DialogStarredSyncBinding.inflate(getLayoutInflater());
+        DialogStarredAlbumSyncBinding bind = DialogStarredAlbumSyncBinding.inflate(getLayoutInflater());
 
         starredAlbumsSyncViewModel = new ViewModelProvider(requireActivity()).get(StarredAlbumsSyncViewModel.class);
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/StarredSyncDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/StarredSyncDialog.java
@@ -26,6 +26,12 @@ import java.util.stream.Collectors;
 public class StarredSyncDialog extends DialogFragment {
     private StarredSyncViewModel starredSyncViewModel;
 
+    private Runnable onCancel;
+
+    public StarredSyncDialog(Runnable onCancel) {
+        this.onCancel = onCancel;
+    }
+
     @NonNull
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
@@ -75,6 +81,7 @@ public class StarredSyncDialog extends DialogFragment {
             Button negativeButton = dialog.getButton(Dialog.BUTTON_NEGATIVE);
             negativeButton.setOnClickListener(v -> {
                 Preferences.setStarredSyncEnabled(false);
+                if (onCancel != null) onCancel.run();
                 dialog.dismiss();
             });
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
@@ -21,6 +21,7 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SwitchPreference;
 
 import com.cappielloantonio.tempo.BuildConfig;
 import com.cappielloantonio.tempo.R;
@@ -257,9 +258,11 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         findPreference("sync_starred_tracks_for_offline_use").setOnPreferenceChangeListener((preference, newValue) -> {
             if (newValue instanceof Boolean) {
                 if ((Boolean) newValue) {
-                    StarredSyncDialog dialog = new StarredSyncDialog();
+                    StarredSyncDialog dialog = new StarredSyncDialog(() -> {
+                        ((SwitchPreference)preference).setChecked(false);
+                    });
                     dialog.show(activity.getSupportFragmentManager(), null);
-                }
+                    }
             }
             return true;
         });
@@ -269,7 +272,9 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         findPreference("sync_starred_albums_for_offline_use").setOnPreferenceChangeListener((preference, newValue) -> {
             if (newValue instanceof Boolean) {
                 if ((Boolean) newValue) {
-                    StarredAlbumSyncDialog dialog = new StarredAlbumSyncDialog();
+                    StarredAlbumSyncDialog dialog = new StarredAlbumSyncDialog(() -> {
+                        ((SwitchPreference)preference).setChecked(false);
+                    });
                     dialog.show(activity.getSupportFragmentManager(), null);
                 }
             }


### PR DESCRIPTION
This PR fixes two bugs:

- When user enables "Sync starred tracks" or "Sync starred albums" settings, the app shows a dialog to confirm. When "Cancel" is clicked in the dialog, previously the switch remained enabled, although the preference was actually set to _false_. Now, it immediately disables the switch for better UX.
- When user enabled "Sync starred albums", previously the dialog showed the same description as "Sync starred tracks" because the view associated was the same (probably due to copy/paste). Now it uses the correct view.