### PR TITLE
feat: Mark currently playing song with play/pause button

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/interfaces/MediaSongIdCallback.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/interfaces/MediaSongIdCallback.java
@@ -1,0 +1,8 @@
+package com.cappielloantonio.tempo.interfaces;
+
+import androidx.annotation.Keep;
+
+@Keep
+public interface MediaSongIdCallback {
+    default void onRecovery(String id) {}
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/interfaces/MediaSongIdCallback.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/interfaces/MediaSongIdCallback.java
@@ -1,8 +1,0 @@
-package com.cappielloantonio.tempo.interfaces;
-
-import androidx.annotation.Keep;
-
-@Keep
-public interface MediaSongIdCallback {
-    default void onRecovery(String id) {}
-}

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -2,17 +2,20 @@ package com.cappielloantonio.tempo.service;
 
 import android.content.ComponentName;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
+import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
 import androidx.media3.common.MediaItem;
+import androidx.media3.common.Player;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.session.MediaBrowser;
 import androidx.media3.session.SessionToken;
 
 import com.cappielloantonio.tempo.App;
 import com.cappielloantonio.tempo.interfaces.MediaIndexCallback;
-import com.cappielloantonio.tempo.interfaces.MediaSongIdCallback;
 import com.cappielloantonio.tempo.model.Chronology;
 import com.cappielloantonio.tempo.repository.ChronologyRepository;
 import com.cappielloantonio.tempo.repository.QueueRepository;
@@ -22,14 +25,88 @@ import com.cappielloantonio.tempo.subsonic.models.InternetRadioStation;
 import com.cappielloantonio.tempo.subsonic.models.PodcastEpisode;
 import com.cappielloantonio.tempo.util.MappingUtil;
 import com.cappielloantonio.tempo.util.Preferences;
+import com.cappielloantonio.tempo.viewmodel.PlaybackViewModel;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 public class MediaManager {
     private static final String TAG = "MediaManager";
+    private static WeakReference<MediaBrowser> attachedBrowserRef = new WeakReference<>(null);
+
+    /**
+     * Attach a Player.Listener to the MediaBrowser (once per browser instance).
+     * Safe to call every time you (re)create the MediaBrowser future (e.g. in Fragment.onStart()).
+     */
+    public static void registerPlaybackObserver(
+            LifecycleOwner lifecycleOwner,
+            ListenableFuture<MediaBrowser> browserFuture,
+            PlaybackViewModel playbackViewModel
+    ) {
+        if (browserFuture == null) return;
+
+        Futures.addCallback(browserFuture, new FutureCallback<MediaBrowser>() {
+            @Override
+            public void onSuccess(MediaBrowser browser) {
+                MediaBrowser current = attachedBrowserRef.get();
+                if (current != browser) {
+                    browser.addListener(new Player.Listener() {
+                        @Override
+                        public void onEvents(@NonNull Player player, @NonNull Player.Events events) {
+                            if (events.contains(Player.EVENT_MEDIA_ITEM_TRANSITION)
+                                    || events.contains(Player.EVENT_PLAY_WHEN_READY_CHANGED)
+                                    || events.contains(Player.EVENT_PLAYBACK_STATE_CHANGED)) {
+
+                                String mediaId = player.getCurrentMediaItem() != null
+                                        ? player.getCurrentMediaItem().mediaId
+                                        : null;
+
+                                boolean playing = player.getPlaybackState() == Player.STATE_READY
+                                        && player.getPlayWhenReady();
+
+                                playbackViewModel.update(mediaId, playing);
+                            }
+                        }
+                    });
+
+                    String mediaId = browser.getCurrentMediaItem() != null
+                            ? browser.getCurrentMediaItem().mediaId
+                            : null;
+                    boolean playing = browser.getPlaybackState() == Player.STATE_READY && browser.getPlayWhenReady();
+                    playbackViewModel.update(mediaId, playing);
+
+                    attachedBrowserRef = new WeakReference<>(browser);
+                } else {
+                    String mediaId = browser.getCurrentMediaItem() != null
+                            ? browser.getCurrentMediaItem().mediaId
+                            : null;
+                    boolean playing = browser.getPlaybackState() == Player.STATE_READY && browser.getPlayWhenReady();
+                    playbackViewModel.update(mediaId, playing);
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Throwable t) {
+                // Log or handle if needed
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    /**
+     * Call this when you truly want to discard the browser (e.g. Activity.onStop()).
+     * If fragments call it, they should accept that next onStart will recreate a browser & listener.
+     */
+    public static void onBrowserReleased(@Nullable MediaBrowser released) {
+        MediaBrowser attached = attachedBrowserRef.get();
+        if (attached == released) {
+            attachedBrowserRef.clear();
+        }
+    }
 
     public static void reset(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture) {
         if (mediaBrowserListenableFuture != null) {
@@ -285,25 +362,6 @@ public class MediaManager {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
                         callback.onRecovery(mediaBrowserListenableFuture.get().getCurrentMediaItemIndex());
-                    }
-                } catch (ExecutionException | InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }, MoreExecutors.directExecutor());
-        }
-    }
-
-    public static void getCurrentSongId(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, MediaSongIdCallback callback) {
-        if (mediaBrowserListenableFuture != null) {
-            mediaBrowserListenableFuture.addListener(() -> {
-                try {
-                    if (mediaBrowserListenableFuture.isDone()) {
-                        MediaItem currentItem = mediaBrowserListenableFuture.get().getCurrentMediaItem();
-                        if (currentItem != null) {
-                            callback.onRecovery(currentItem.mediaMetadata.extras.getString("id"));
-                        } else {
-                            callback.onRecovery(null);
-                        }
                     }
                 } catch (ExecutionException | InterruptedException e) {
                     e.printStackTrace();

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -1,6 +1,7 @@
 package com.cappielloantonio.tempo.service;
 
 import android.content.ComponentName;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -39,12 +40,7 @@ public class MediaManager {
     private static final String TAG = "MediaManager";
     private static WeakReference<MediaBrowser> attachedBrowserRef = new WeakReference<>(null);
 
-    /**
-     * Attach a Player.Listener to the MediaBrowser (once per browser instance).
-     * Safe to call every time you (re)create the MediaBrowser future (e.g. in Fragment.onStart()).
-     */
     public static void registerPlaybackObserver(
-            LifecycleOwner lifecycleOwner,
             ListenableFuture<MediaBrowser> browserFuture,
             PlaybackViewModel playbackViewModel
     ) {
@@ -92,15 +88,11 @@ public class MediaManager {
 
             @Override
             public void onFailure(@NonNull Throwable t) {
-                // Log or handle if needed
+                Log.e(TAG, "Failed to get MediaBrowser instance", t);
             }
         }, MoreExecutors.directExecutor());
     }
 
-    /**
-     * Call this when you truly want to discard the browser (e.g. Activity.onStop()).
-     * If fragments call it, they should accept that next onStart will recreate a browser & listener.
-     */
     public static void onBrowserReleased(@Nullable MediaBrowser released) {
         MediaBrowser attached = attachedBrowserRef.get();
         if (attached == released) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -12,6 +12,7 @@ import androidx.media3.session.SessionToken;
 
 import com.cappielloantonio.tempo.App;
 import com.cappielloantonio.tempo.interfaces.MediaIndexCallback;
+import com.cappielloantonio.tempo.interfaces.MediaSongIdCallback;
 import com.cappielloantonio.tempo.model.Chronology;
 import com.cappielloantonio.tempo.repository.ChronologyRepository;
 import com.cappielloantonio.tempo.repository.QueueRepository;
@@ -284,6 +285,25 @@ public class MediaManager {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
                         callback.onRecovery(mediaBrowserListenableFuture.get().getCurrentMediaItemIndex());
+                    }
+                } catch (ExecutionException | InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }, MoreExecutors.directExecutor());
+        }
+    }
+
+    public static void getCurrentSongId(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, MediaSongIdCallback callback) {
+        if (mediaBrowserListenableFuture != null) {
+            mediaBrowserListenableFuture.addListener(() -> {
+                try {
+                    if (mediaBrowserListenableFuture.isDone()) {
+                        MediaItem currentItem = mediaBrowserListenableFuture.get().getCurrentMediaItem();
+                        if (currentItem != null) {
+                            callback.onRecovery(currentItem.mediaMetadata.extras.getString("id"));
+                        } else {
+                            callback.onRecovery(null);
+                        }
                     }
                 } catch (ExecutionException | InterruptedException e) {
                     e.printStackTrace();

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
@@ -17,6 +17,7 @@ import com.cappielloantonio.tempo.databinding.ItemPlayerQueueSongBinding;
 import com.cappielloantonio.tempo.glide.CustomGlideRequest;
 import com.cappielloantonio.tempo.interfaces.ClickCallback;
 import com.cappielloantonio.tempo.interfaces.MediaIndexCallback;
+import com.cappielloantonio.tempo.interfaces.MediaSongIdCallback;
 import com.cappielloantonio.tempo.service.MediaManager;
 import com.cappielloantonio.tempo.subsonic.models.Child;
 import com.cappielloantonio.tempo.util.Constants;
@@ -82,6 +83,19 @@ public class PlayerSongQueueAdapter extends RecyclerView.Adapter<PlayerSongQueue
                     holder.item.queueSongTitleTextView.setAlpha(1.0f);
                     holder.item.queueSongSubtitleTextView.setAlpha(1.0f);
                     holder.item.ratingIndicatorImageView.setAlpha(1.0f);
+                }
+            }
+        });
+
+        MediaManager.getCurrentSongId(mediaBrowserListenableFuture, new MediaSongIdCallback() {
+            @Override
+            public void onRecovery(String id) {
+                if (song.getId().equals(id)) {
+                    holder.item.playPauseIcon.setVisibility(View.VISIBLE);
+                    holder.item.coverArtOverlay.setVisibility(View.VISIBLE);
+                } else {
+                    holder.item.playPauseIcon.setVisibility(View.INVISIBLE);
+                    holder.item.coverArtOverlay.setVisibility(View.INVISIBLE);
                 }
             }
         });

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlayerSongQueueAdapter.java
@@ -1,6 +1,5 @@
 package com.cappielloantonio.tempo.ui.adapter;
 
-import android.app.Activity;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.util.Log;

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
@@ -322,7 +322,8 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
         public void onClick() {
             Bundle bundle = new Bundle();
             bundle.putParcelableArrayList(Constants.TRACKS_OBJECT, new ArrayList<>(MusicUtil.limitPlayableMedia(songs, getBindingAdapterPosition())));
-            bundle.putInt( Constants.ITEM_POSITION, MusicUtil.getPlayableMediaPosition(songs, getBindingAdapterPosition()));
+            bundle.putInt(Constants.ITEM_POSITION, MusicUtil.getPlayableMediaPosition(songs, getBindingAdapterPosition()));
+
             click.onMediaClick(bundle);
         }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
@@ -10,12 +10,15 @@ import android.widget.Filterable;
 import androidx.annotation.NonNull;
 import androidx.appcompat.content.res.AppCompatResources;
 import androidx.media3.common.util.UnstableApi;
+import androidx.media3.session.MediaBrowser;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.databinding.ItemHorizontalTrackBinding;
 import com.cappielloantonio.tempo.glide.CustomGlideRequest;
 import com.cappielloantonio.tempo.interfaces.ClickCallback;
+import com.cappielloantonio.tempo.interfaces.MediaSongIdCallback;
+import com.cappielloantonio.tempo.service.MediaManager;
 import com.cappielloantonio.tempo.subsonic.models.AlbumID3;
 import com.cappielloantonio.tempo.subsonic.models.Child;
 import com.cappielloantonio.tempo.subsonic.models.DiscTitle;
@@ -23,6 +26,7 @@ import com.cappielloantonio.tempo.util.Constants;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 import com.cappielloantonio.tempo.util.MusicUtil;
 import com.cappielloantonio.tempo.util.Preferences;
+import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,6 +45,7 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
     private List<Child> songsFull;
     private List<Child> songs;
     private String currentFilter;
+    private ListenableFuture<MediaBrowser> mediaBrowserListenableFuture;
 
     private final Filter filtering = new Filter() {
         @Override
@@ -165,6 +170,21 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
         } else {
             holder.item.ratingIndicatorImageView.setVisibility(View.GONE);
         }
+
+        MediaManager.getCurrentSongId(mediaBrowserListenableFuture, new MediaSongIdCallback() {
+            @Override
+            public void onRecovery(String id) {
+                if (song.getId().equals(id)) {
+                    holder.item.playPauseIcon.setVisibility(View.VISIBLE);
+                    if (!showCoverArt) holder.item.trackNumberTextView.setVisibility(View.INVISIBLE);
+                    if (showCoverArt) holder.item.coverArtOverlay.setVisibility(View.VISIBLE);
+                } else {
+                    holder.item.playPauseIcon.setVisibility(View.INVISIBLE);
+                    if (showCoverArt) holder.item.coverArtOverlay.setVisibility(View.INVISIBLE);
+                    if (!showCoverArt) holder.item.trackNumberTextView.setVisibility(View.VISIBLE);
+                }
+            }
+        });
     }
 
     @Override
@@ -246,5 +266,9 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
         }
 
         notifyDataSetChanged();
+    }
+
+    public void setMediaBrowserListenableFuture(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture) {
+        this.mediaBrowserListenableFuture = mediaBrowserListenableFuture;
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
@@ -240,6 +240,7 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
     public void setItems(List<Child> songs) {
         this.songsFull = songs != null ? songs : Collections.emptyList();
         filtering.filter(currentFilter);
+        notifyDataSetChanged();
     }
 
     @Override
@@ -320,21 +321,17 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
 
         public void onClick() {
             Bundle bundle = new Bundle();
-            bundle.putParcelableArrayList(
-                    Constants.TRACKS_OBJECT,
-                    new ArrayList<>(MusicUtil.limitPlayableMedia(songs, getBindingAdapterPosition()))
-            );
-            bundle.putInt(
-                    Constants.ITEM_POSITION,
-                    MusicUtil.getPlayableMediaPosition(songs, getBindingAdapterPosition())
-            );
+            bundle.putParcelableArrayList(Constants.TRACKS_OBJECT, new ArrayList<>(MusicUtil.limitPlayableMedia(songs, getBindingAdapterPosition())));
+            bundle.putInt( Constants.ITEM_POSITION, MusicUtil.getPlayableMediaPosition(songs, getBindingAdapterPosition()));
             click.onMediaClick(bundle);
         }
 
         private boolean onLongClick() {
             Bundle bundle = new Bundle();
             bundle.putParcelable(Constants.TRACK_OBJECT, songs.get(getBindingAdapterPosition()));
+
             click.onMediaLongClick(bundle);
+
             return true;
         }
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -307,7 +307,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
     }
 
     private void observePlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (songHorizontalAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
@@ -315,7 +315,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (songHorizontalAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
@@ -323,7 +323,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
 
     private void reapplyPlayback() {
         if (songHorizontalAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -94,6 +94,12 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        setMediaBrowserListenableFuture();
+    }
+
+    @Override
     public void onStop() {
         releaseMediaBrowser();
         super.onStop();
@@ -271,6 +277,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
 
                 songHorizontalAdapter = new SongHorizontalAdapter(this, false, false, album);
                 bind.songRecyclerView.setAdapter(songHorizontalAdapter);
+                setMediaBrowserListenableFuture();
 
                 albumPageViewModel.getAlbumSongLiveList().observe(getViewLifecycleOwner(), songs -> songHorizontalAdapter.setItems(songs));
             }
@@ -288,11 +295,18 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
     @Override
     public void onMediaClick(Bundle bundle) {
         MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
+        songHorizontalAdapter.notifyDataSetChanged();
         activity.setBottomSheetInPeek(true);
     }
 
     @Override
     public void onMediaLongClick(Bundle bundle) {
         Navigation.findNavController(requireView()).navigate(R.id.songBottomSheetDialog, bundle);
+    }
+
+    private void setMediaBrowserListenableFuture() {
+        if (songHorizontalAdapter != null) {
+            songHorizontalAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -95,7 +95,7 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
 
         initializeMediaBrowser();
 
-        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        MediaManager.registerPlaybackObserver(mediaBrowserListenableFuture, playbackViewModel);
         observePlayback();
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
@@ -83,7 +83,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
         super.onStart();
 
         initializeMediaBrowser();
-        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        MediaManager.registerPlaybackObserver(mediaBrowserListenableFuture, playbackViewModel);
         observePlayback();
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
@@ -83,6 +83,12 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        setMediaBrowserListenableFuture();
+    }
+
+    @Override
     public void onStop() {
         releaseMediaBrowser();
         super.onStop();
@@ -174,6 +180,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
 
         songHorizontalAdapter = new SongHorizontalAdapter(this, true, true, null);
         bind.mostStreamedSongRecyclerView.setAdapter(songHorizontalAdapter);
+        setMediaBrowserListenableFuture();
         artistPageViewModel.getArtistTopSongList().observe(getViewLifecycleOwner(), songs -> {
             if (songs == null) {
                 if (bind != null) bind.artistPageTopSongsSector.setVisibility(View.GONE);
@@ -246,6 +253,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
     @Override
     public void onMediaClick(Bundle bundle) {
         MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
+        songHorizontalAdapter.notifyDataSetChanged();
         activity.setBottomSheetInPeek(true);
     }
 
@@ -272,5 +280,11 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
     @Override
     public void onArtistLongClick(Bundle bundle) {
         Navigation.findNavController(requireView()).navigate(R.id.artistBottomSheetDialog, bundle);
+    }
+
+    private void setMediaBrowserListenableFuture() {
+        if (songHorizontalAdapter != null) {
+            songHorizontalAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
@@ -29,20 +29,16 @@ import com.cappielloantonio.tempo.service.MediaManager;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.cappielloantonio.tempo.subsonic.models.ArtistID3;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
-import com.cappielloantonio.tempo.ui.adapter.AlbumArtistPageOrSimilarAdapter;
 import com.cappielloantonio.tempo.ui.adapter.AlbumCatalogueAdapter;
 import com.cappielloantonio.tempo.ui.adapter.ArtistCatalogueAdapter;
-import com.cappielloantonio.tempo.ui.adapter.ArtistSimilarAdapter;
 import com.cappielloantonio.tempo.ui.adapter.SongHorizontalAdapter;
 import com.cappielloantonio.tempo.util.Constants;
 import com.cappielloantonio.tempo.util.MusicUtil;
-import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.ArtistPageViewModel;
 import com.cappielloantonio.tempo.viewmodel.PlaybackViewModel;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @UnstableApi
@@ -282,7 +278,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
     }
 
     private void observePlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (songHorizontalAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
@@ -290,7 +286,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (songHorizontalAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
@@ -298,7 +294,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
 
     private void reapplyPlayback() {
         if (songHorizontalAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -1058,7 +1058,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
     }
 
     private void observeStarredSongsPlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (starredSongAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 starredSongAdapter.setPlaybackState(id, playing != null && playing);
@@ -1066,14 +1066,14 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (starredSongAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 starredSongAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
     }
 
     private void observeTopSongsPlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (topSongAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 topSongAdapter.setPlaybackState(id, playing != null && playing);
@@ -1081,7 +1081,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (topSongAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 topSongAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
@@ -1089,7 +1089,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
 
     private void reapplyStarredSongsPlayback() {
         if (starredSongAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             starredSongAdapter.setPlaybackState(id, playing != null && playing);
         }
@@ -1097,7 +1097,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
 
     private void reapplyTopSongsPlayback() {
         if (topSongAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             topSongAdapter.setPlaybackState(id, playing != null && playing);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -144,6 +144,8 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
     public void onResume() {
         super.onResume();
         refreshSharesView();
+        setTopSongMediaBrowserListenableFuture();
+        setStarredSongMediaBrowserListenableFuture();
     }
 
     @Override
@@ -477,6 +479,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
 
         topSongAdapter = new SongHorizontalAdapter(this, true, false, null);
         bind.topSongsRecyclerView.setAdapter(topSongAdapter);
+        setTopSongMediaBrowserListenableFuture();
         homeViewModel.getChronologySample(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), chronologies -> {
             if (chronologies == null || chronologies.isEmpty()) {
                 if (bind != null) bind.homeGridTracksSector.setVisibility(View.GONE);
@@ -515,6 +518,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
 
         starredSongAdapter = new SongHorizontalAdapter(this, true, false, null);
         bind.starredTracksRecyclerView.setAdapter(starredSongAdapter);
+        setStarredSongMediaBrowserListenableFuture();
         homeViewModel.getStarredTracks(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), songs -> {
             if (songs == null) {
                 if (bind != null) bind.starredTracksSector.setVisibility(View.GONE);
@@ -954,6 +958,8 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
             MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
             activity.setBottomSheetInPeek(true);
         }
+        topSongAdapter.notifyDataSetChanged();
+        starredSongAdapter.notifyDataSetChanged();
     }
 
     @Override
@@ -1042,5 +1048,17 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
     @Override
     public void onShareLongClick(Bundle bundle) {
         Navigation.findNavController(requireView()).navigate(R.id.shareBottomSheetDialog, bundle);
+    }
+
+    private void setTopSongMediaBrowserListenableFuture() {
+        if (topSongAdapter != null) {
+            topSongAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+        }
+    }
+
+    private void setStarredSongMediaBrowserListenableFuture() {
+        if (starredSongAdapter != null) {
+            starredSongAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -142,7 +142,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
 
         initializeMediaBrowser();
 
-        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        MediaManager.registerPlaybackObserver(mediaBrowserListenableFuture, playbackViewModel);
         observeStarredSongsPlayback();
         observeTopSongsPlayback();
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
@@ -110,6 +110,7 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
 
         playerSongQueueAdapter = new PlayerSongQueueAdapter(this);
         bind.playerQueueRecyclerView.setAdapter(playerSongQueueAdapter);
+        setMediaBrowserListenableFuture();
         playerBottomSheetViewModel.getQueueSong().observe(getViewLifecycleOwner(), queue -> {
             if (queue != null) {
                 playerSongQueueAdapter.setItems(queue.stream().map(item -> (Child) item).collect(Collectors.toList()));
@@ -215,5 +216,6 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
     @Override
     public void onMediaClick(Bundle bundle) {
         MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
+        updateNowPlayingItem();
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
@@ -63,7 +63,7 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
         initializeBrowser();
         bindMediaController();
 
-        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        MediaManager.registerPlaybackObserver(mediaBrowserListenableFuture, playbackViewModel);
         observePlayback();
     }
 
@@ -71,6 +71,7 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
     public void onResume() {
         super.onResume();
         setMediaBrowserListenableFuture();
+        updateNowPlayingItem();
     }
 
     @Override
@@ -214,6 +215,10 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
             MediaManager.removeRange(mediaBrowserListenableFuture, playerSongQueueAdapter.getItems(), startPosition, endPosition);
             bind.playerQueueRecyclerView.getAdapter().notifyItemRangeRemoved(startPosition, endPosition);
         });
+    }
+
+    private void updateNowPlayingItem() {
+        playerSongQueueAdapter.notifyDataSetChanged();
     }
 
     @Override

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
@@ -227,7 +227,7 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
     }
 
     private void observePlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (playerSongQueueAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 playerSongQueueAdapter.setPlaybackState(id, playing != null && playing);
@@ -235,7 +235,7 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (playerSongQueueAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 playerSongQueueAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
@@ -243,7 +243,7 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
 
     private void reapplyPlayback() {
         if (playerSongQueueAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             playerSongQueueAdapter.setPlaybackState(id, playing != null && playing);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -112,6 +112,12 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        setMediaBrowserListenableFuture();
+    }
+
+    @Override
     public void onStop() {
         releaseMediaBrowser();
         super.onStop();
@@ -248,6 +254,7 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
 
         songHorizontalAdapter = new SongHorizontalAdapter(this, true, false, null);
         bind.songRecyclerView.setAdapter(songHorizontalAdapter);
+        setMediaBrowserListenableFuture();
 
         playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> songHorizontalAdapter.setItems(songs));
     }
@@ -263,11 +270,18 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
     @Override
     public void onMediaClick(Bundle bundle) {
         MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
+        songHorizontalAdapter.notifyDataSetChanged();
         activity.setBottomSheetInPeek(true);
     }
 
     @Override
     public void onMediaLongClick(Bundle bundle) {
         Navigation.findNavController(requireView()).navigate(R.id.songBottomSheetDialog, bundle);
+    }
+
+    private void setMediaBrowserListenableFuture() {
+        if (songHorizontalAdapter != null) {
+            songHorizontalAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -113,7 +113,7 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
 
         initializeMediaBrowser();
 
-        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        MediaManager.registerPlaybackObserver(mediaBrowserListenableFuture, playbackViewModel);
         observePlayback();
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -282,7 +282,7 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
     }
 
     private void observePlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (songHorizontalAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
@@ -290,7 +290,7 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (songHorizontalAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
@@ -298,7 +298,7 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
 
     private void reapplyPlayback() {
         if (songHorizontalAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
@@ -76,6 +76,12 @@ public class SearchFragment extends Fragment implements ClickCallback {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        setMediaBrowserListenableFuture();
+    }
+
+    @Override
     public void onStop() {
         releaseMediaBrowser();
         super.onStop();
@@ -113,6 +119,7 @@ public class SearchFragment extends Fragment implements ClickCallback {
         bind.searchResultTracksRecyclerView.setHasFixedSize(true);
 
         songHorizontalAdapter = new SongHorizontalAdapter(this, true, false, null);
+        setMediaBrowserListenableFuture();
         bind.searchResultTracksRecyclerView.setAdapter(songHorizontalAdapter);
     }
 
@@ -260,6 +267,7 @@ public class SearchFragment extends Fragment implements ClickCallback {
     @Override
     public void onMediaClick(Bundle bundle) {
         MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
+        songHorizontalAdapter.notifyDataSetChanged();
         activity.setBottomSheetInPeek(true);
     }
 
@@ -286,5 +294,11 @@ public class SearchFragment extends Fragment implements ClickCallback {
     @Override
     public void onArtistLongClick(Bundle bundle) {
         Navigation.findNavController(requireView()).navigate(R.id.artistBottomSheetDialog, bundle);
+    }
+
+    private void setMediaBrowserListenableFuture() {
+        if (songHorizontalAdapter != null) {
+            songHorizontalAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
@@ -77,7 +77,7 @@ public class SearchFragment extends Fragment implements ClickCallback {
         super.onStart();
         initializeMediaBrowser();
 
-        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        MediaManager.registerPlaybackObserver(mediaBrowserListenableFuture, playbackViewModel);
         observePlayback();
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
@@ -4,14 +4,11 @@ import android.content.ComponentName;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.inputmethod.EditorInfo;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -303,7 +300,7 @@ public class SearchFragment extends Fragment implements ClickCallback {
     }
 
     private void observePlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (songHorizontalAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
@@ -311,7 +308,7 @@ public class SearchFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (songHorizontalAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
@@ -319,7 +316,7 @@ public class SearchFragment extends Fragment implements ClickCallback {
 
     private void reapplyPlayback() {
         if (songHorizontalAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
@@ -335,7 +335,7 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
     }
 
     private void observePlayback() {
-        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+        playbackViewModel.getCurrentSongId().observe(getViewLifecycleOwner(), id -> {
             if (songHorizontalAdapter != null) {
                 Boolean playing = playbackViewModel.getIsPlaying().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
@@ -343,7 +343,7 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
         });
         playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
             if (songHorizontalAdapter != null) {
-                String id = playbackViewModel.getCurrentMediaId().getValue();
+                String id = playbackViewModel.getCurrentSongId().getValue();
                 songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
             }
         });
@@ -351,7 +351,7 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
 
     private void reapplyPlayback() {
         if (songHorizontalAdapter != null) {
-            String id = playbackViewModel.getCurrentMediaId().getValue();
+            String id = playbackViewModel.getCurrentSongId().getValue();
             Boolean playing = playbackViewModel.getIsPlaying().getValue();
             songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
@@ -85,6 +85,12 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        setMediaBrowserListenableFuture();
+    }
+
+    @Override
     public void onStop() {
         releaseMediaBrowser();
         super.onStop();
@@ -191,6 +197,7 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
 
         songHorizontalAdapter = new SongHorizontalAdapter(this, true, false, null);
         bind.songListRecyclerView.setAdapter(songHorizontalAdapter);
+        setMediaBrowserListenableFuture();
         songListPageViewModel.getSongList().observe(getViewLifecycleOwner(), songs -> {
             isLoading = false;
             songHorizontalAdapter.setItems(songs);
@@ -318,11 +325,18 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
     public void onMediaClick(Bundle bundle) {
         hideKeyboard(requireView());
         MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
+        songHorizontalAdapter.notifyDataSetChanged();
         activity.setBottomSheetInPeek(true);
     }
 
     @Override
     public void onMediaLongClick(Bundle bundle) {
         Navigation.findNavController(requireView()).navigate(R.id.songBottomSheetDialog, bundle);
+    }
+
+    private void setMediaBrowserListenableFuture() {
+        if (songHorizontalAdapter != null) {
+            songHorizontalAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
@@ -86,7 +86,7 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
         super.onStart();
         initializeMediaBrowser();
 
-        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        MediaManager.registerPlaybackObserver(mediaBrowserListenableFuture, playbackViewModel);
         observePlayback();
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
@@ -36,6 +36,7 @@ import com.cappielloantonio.tempo.subsonic.models.Child;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.SongHorizontalAdapter;
 import com.cappielloantonio.tempo.util.Constants;
+import com.cappielloantonio.tempo.viewmodel.PlaybackViewModel;
 import com.cappielloantonio.tempo.viewmodel.SongListPageViewModel;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -49,6 +50,7 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
     private FragmentSongListPageBinding bind;
     private MainActivity activity;
     private SongListPageViewModel songListPageViewModel;
+    private PlaybackViewModel playbackViewModel;
 
     private SongHorizontalAdapter songHorizontalAdapter;
 
@@ -69,6 +71,7 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
         bind = FragmentSongListPageBinding.inflate(inflater, container, false);
         View view = bind.getRoot();
         songListPageViewModel = new ViewModelProvider(requireActivity()).get(SongListPageViewModel.class);
+        playbackViewModel = new ViewModelProvider(requireActivity()).get(PlaybackViewModel.class);
 
         init();
         initAppBar();
@@ -82,12 +85,9 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
     public void onStart() {
         super.onStart();
         initializeMediaBrowser();
-    }
 
-    @Override
-    public void onResume() {
-        super.onResume();
-        setMediaBrowserListenableFuture();
+        MediaManager.registerPlaybackObserver(getViewLifecycleOwner(), mediaBrowserListenableFuture, playbackViewModel);
+        observePlayback();
     }
 
     @Override
@@ -197,10 +197,11 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
 
         songHorizontalAdapter = new SongHorizontalAdapter(this, true, false, null);
         bind.songListRecyclerView.setAdapter(songHorizontalAdapter);
-        setMediaBrowserListenableFuture();
+        reapplyPlayback();
         songListPageViewModel.getSongList().observe(getViewLifecycleOwner(), songs -> {
             isLoading = false;
             songHorizontalAdapter.setItems(songs);
+            reapplyPlayback();
             setSongListPageSubtitle(songs);
         });
 
@@ -325,7 +326,6 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
     public void onMediaClick(Bundle bundle) {
         hideKeyboard(requireView());
         MediaManager.startQueue(mediaBrowserListenableFuture, bundle.getParcelableArrayList(Constants.TRACKS_OBJECT), bundle.getInt(Constants.ITEM_POSITION));
-        songHorizontalAdapter.notifyDataSetChanged();
         activity.setBottomSheetInPeek(true);
     }
 
@@ -334,9 +334,26 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
         Navigation.findNavController(requireView()).navigate(R.id.songBottomSheetDialog, bundle);
     }
 
-    private void setMediaBrowserListenableFuture() {
+    private void observePlayback() {
+        playbackViewModel.getCurrentMediaId().observe(getViewLifecycleOwner(), id -> {
+            if (songHorizontalAdapter != null) {
+                Boolean playing = playbackViewModel.getIsPlaying().getValue();
+                songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
+            }
+        });
+        playbackViewModel.getIsPlaying().observe(getViewLifecycleOwner(), playing -> {
+            if (songHorizontalAdapter != null) {
+                String id = playbackViewModel.getCurrentMediaId().getValue();
+                songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
+            }
+        });
+    }
+
+    private void reapplyPlayback() {
         if (songHorizontalAdapter != null) {
-            songHorizontalAdapter.setMediaBrowserListenableFuture(mediaBrowserListenableFuture);
+            String id = playbackViewModel.getCurrentMediaId().getValue();
+            Boolean playing = playbackViewModel.getIsPlaying().getValue();
+            songHorizontalAdapter.setPlaybackState(id, playing != null && playing);
         }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PlaybackViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PlaybackViewModel.java
@@ -8,20 +8,20 @@ import java.util.Objects;
 
 public class PlaybackViewModel extends ViewModel {
 
-    private final MutableLiveData<String> currentMediaId = new MutableLiveData<>(null);
+    private final MutableLiveData<String> currentSongId = new MutableLiveData<>(null);
     private final MutableLiveData<Boolean> isPlaying = new MutableLiveData<>(false);
 
-    public LiveData<String> getCurrentMediaId() {
-        return currentMediaId;
+    public LiveData<String> getCurrentSongId() {
+        return currentSongId;
     }
 
     public LiveData<Boolean> getIsPlaying() {
         return isPlaying;
     }
 
-    public void update(String mediaId, boolean playing) {
-        if (!Objects.equals(currentMediaId.getValue(), mediaId)) {
-            currentMediaId.postValue(mediaId);
+    public void update(String songId, boolean playing) {
+        if (!Objects.equals(currentSongId.getValue(), songId)) {
+            currentSongId.postValue(songId);
         }
         if (!Objects.equals(isPlaying.getValue(), playing)) {
             isPlaying.postValue(playing);
@@ -29,7 +29,7 @@ public class PlaybackViewModel extends ViewModel {
     }
 
     public void clear() {
-        currentMediaId.postValue(null);
+        currentSongId.postValue(null);
         isPlaying.postValue(false);
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PlaybackViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PlaybackViewModel.java
@@ -11,9 +11,6 @@ public class PlaybackViewModel extends ViewModel {
     private final MutableLiveData<String> currentMediaId = new MutableLiveData<>(null);
     private final MutableLiveData<Boolean> isPlaying = new MutableLiveData<>(false);
 
-    // (Optional) expose position or other info
-    // private final MutableLiveData<Long> positionMs = new MutableLiveData<>(0L);
-
     public LiveData<String> getCurrentMediaId() {
         return currentMediaId;
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PlaybackViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PlaybackViewModel.java
@@ -1,0 +1,38 @@
+package com.cappielloantonio.tempo.viewmodel;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+import java.util.Objects;
+
+public class PlaybackViewModel extends ViewModel {
+
+    private final MutableLiveData<String> currentMediaId = new MutableLiveData<>(null);
+    private final MutableLiveData<Boolean> isPlaying = new MutableLiveData<>(false);
+
+    // (Optional) expose position or other info
+    // private final MutableLiveData<Long> positionMs = new MutableLiveData<>(0L);
+
+    public LiveData<String> getCurrentMediaId() {
+        return currentMediaId;
+    }
+
+    public LiveData<Boolean> getIsPlaying() {
+        return isPlaying;
+    }
+
+    public void update(String mediaId, boolean playing) {
+        if (!Objects.equals(currentMediaId.getValue(), mediaId)) {
+            currentMediaId.postValue(mediaId);
+        }
+        if (!Objects.equals(isPlaying.getValue(), playing)) {
+            isPlaying.postValue(playing);
+        }
+    }
+
+    public void clear() {
+        currentMediaId.postValue(null);
+        isPlaying.postValue(false);
+    }
+}

--- a/app/src/main/res/layout/item_horizontal_track.xml
+++ b/app/src/main/res/layout/item_horizontal_track.xml
@@ -75,7 +75,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector"
-        android:src="@drawable/button_play_pause_selector" />
+        android:src="@drawable/ic_play" />
 
     <TextView
         android:id="@+id/track_number_text_view"

--- a/app/src/main/res/layout/item_horizontal_track.xml
+++ b/app/src/main/res/layout/item_horizontal_track.xml
@@ -66,16 +66,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector" />
 
-    <ImageView
-        android:id="@+id/play_pause_icon"
+    <ToggleButton
+        android:id="@+id/play_pause_button"
         android:layout_width="28dp"
         android:layout_height="28dp"
         android:layout_marginStart="28dp"
         android:visibility="gone"
+        android:background="@drawable/button_play_pause_selector"
+        android:checked="false"
+        android:foreground="?android:attr/selectableItemBackgroundBorderless"
+        android:text=""
+        android:textOff=""
+        android:textOn=""
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector"
-        android:src="@drawable/ic_play" />
+        app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector" />
 
     <TextView
         android:id="@+id/track_number_text_view"

--- a/app/src/main/res/layout/item_horizontal_track.xml
+++ b/app/src/main/res/layout/item_horizontal_track.xml
@@ -55,6 +55,28 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector" />
 
+    <View
+        android:id="@+id/cover_art_overlay"
+        android:layout_width="52dp"
+        android:layout_height="52dp"
+        android:layout_marginStart="16dp"
+        android:background="#80000000"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/song_cover_image_view"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector" />
+
+    <ImageView
+        android:id="@+id/play_pause_icon"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_marginStart="28dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector"
+        android:src="@drawable/button_play_pause_selector" />
+
     <TextView
         android:id="@+id/track_number_text_view"
         style="@style/LabelLarge"

--- a/app/src/main/res/layout/item_player_queue_song.xml
+++ b/app/src/main/res/layout/item_player_queue_song.xml
@@ -20,6 +20,28 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/cover_art_overlay"
+        android:layout_width="52dp"
+        android:layout_height="52dp"
+        android:layout_marginStart="2dp"
+        android:background="#80000000"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/play_pause_icon"
+        android:layout_width="28dp"
+        android:layout_height="28dp"
+        android:layout_marginStart="14dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:src="@drawable/button_play_pause_selector" />
+
     <TextView
         android:id="@+id/queue_song_title_text_view"
         style="@style/LabelMedium"

--- a/app/src/main/res/layout/item_player_queue_song.xml
+++ b/app/src/main/res/layout/item_player_queue_song.xml
@@ -40,7 +40,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:src="@drawable/button_play_pause_selector" />
+        android:src="@drawable/ic_play" />
 
     <TextView
         android:id="@+id/queue_song_title_text_view"

--- a/app/src/main/res/layout/item_player_queue_song.xml
+++ b/app/src/main/res/layout/item_player_queue_song.xml
@@ -31,16 +31,21 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <ImageView
-        android:id="@+id/play_pause_icon"
+    <ToggleButton
+        android:id="@+id/play_pause_button"
         android:layout_width="28dp"
         android:layout_height="28dp"
         android:layout_marginStart="14dp"
         android:visibility="gone"
+        android:background="@drawable/button_play_pause_selector"
+        android:checked="false"
+        android:foreground="?android:attr/selectableItemBackgroundBorderless"
+        android:text=""
+        android:textOff=""
+        android:textOn=""
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:src="@drawable/ic_play" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/queue_song_title_text_view"


### PR DESCRIPTION
This PR adds support for marking the current playing song in all song list views. This should resolve #103.

If the song item displays album art, an overlay with a darkened background and a play/pause button is shown. If the song item displays a track number instead, the play/pause button replaces the number. This button can be used to resume playback or pause the current song.

If a song appears more than once in a list, all of its instances will show the play/pause icon at the same time (useful to detect duplicates).

## Changes
- Add a new ViewModel `PlaybackViewModel`.
- Add a method in `MediaManager` to register observer and manage playback state.
- Add play/pause button and album art overlay in `item_horizontal_track.xml` and `item_player_queue_song.xml`.
- Update `SongHorizontalAdapter` and `PlayerSongQueueAdapter` to use these new views and manage them.
- Update all related fragments: `AlbumPageFragment`, `ArtistPageFragment`, `HomeTabMusicFragment`, `PlayerQueueFragment`, `PlaylistPageFragment`, `SearchFragment` and `SongListPageFragment`.

## Screenshots
<p>
  <img src="https://github.com/user-attachments/assets/0a45cf5d-f35b-43d5-ad1f-566a1becad71" width="250">
  <img src="https://github.com/user-attachments/assets/fc8ee533-8555-4432-96e8-41a9d8e3c51a" width="250">
</p>
<p>
  <img src="https://github.com/user-attachments/assets/14905a87-d5e4-4213-b166-6bb98d4cda2f" width="250">
  <img src="https://github.com/user-attachments/assets/dac1e143-1c19-4bf3-a4ec-66d54c9d1090" width="250">
</p>
