### PR TITLE
fix: Update search query validation to require at least 2 characters instead of 3

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
@@ -254,7 +254,7 @@ public class SearchFragment extends Fragment implements ClickCallback {
     }
 
     private boolean isQueryValid(String query) {
-        return !query.equals("") && query.trim().length() > 2;
+        return !query.equals("") && query.trim().length() > 1;
     }
 
     private void inputFocus() {


### PR DESCRIPTION
Previously, it was at least 3 characters, which was sometimes a bit annoying. I think it’s better to lower it to 2 characters.